### PR TITLE
Add Git S3 backup

### DIFF
--- a/git-s3-backup/README.md
+++ b/git-s3-backup/README.md
@@ -1,0 +1,28 @@
+# git-s3-backup
+
+Backs up a Git repository to an Amazon S3 bucket.
+
+## Usage
+
+```
+name: Git backup
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  backup:
+    name: Git backup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1 # Set the region of the bucket
+      - uses: futurelearn/actions/git-s3-backup@main
+        with:
+          bucket: my-bucket # required
+          prefix: backups # defaults to "current"
+```

--- a/git-s3-backup/action.yml
+++ b/git-s3-backup/action.yml
@@ -1,0 +1,18 @@
+name: Git S3 Backup
+description: Backup a Git repository to an S3 bucket
+inputs:
+  bucket:
+    description: The name of the S3 bucket to backup to
+    required: true
+  prefix:
+    description: The S3 key prefix for the object
+    required: true
+    default: current
+runs:
+  using: "composite"
+  steps:
+    - run: ${{ github.action_path }}/run.sh
+      shell: bash
+      env:
+        S3_BUCKET: ${{ inputs.bucket }}
+        S3_PREFIX: ${{ inputs.prefix }}

--- a/git-s3-backup/run.sh
+++ b/git-s3-backup/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eou pipefail
+
+DATE=$(date +%F)
+FILENAME="$GITHUB_REPOSITORY/$DATE.tgz"
+
+git archive --format=tar HEAD | gzip > "$FILENAME"
+aws s3 cp "$FILENAME" "s3://$S3_BUCKET/$S3_PREFIX/$FILENAME"


### PR DESCRIPTION
https://trello.com/c/vS45yVcp/1294-migrate-git-backups

This allows you to easily backup your repository to an S3 bucket. Backing up a Git repository from GitHub is useful if you lose access to GitHub for whatever reason.