### PR TITLE
Block fixup/squash commits

### DIFF
--- a/block-fixups/README.md
+++ b/block-fixups/README.md
@@ -1,0 +1,22 @@
+# Block fixups
+
+Checks if a PR has fixup or squash commits. 
+
+## How to use
+
+```
+name: Block fixup/squash commits
+on:
+  push:
+    branches-ignore: [ $default-branch ]
+
+jobs:
+  block-fixups:
+    name: Block fixups
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: futurelearn/actions/block-fixups@main
+```

--- a/block-fixups/action.yml
+++ b/block-fixups/action.yml
@@ -1,0 +1,9 @@
+name: Block fixup commits
+description: Alert on a PR when we have a fixup commit
+runs:
+  using: "composite"
+  steps:
+    - run: ${{ github.action_path }}/run.sh
+      shell: bash
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/block-fixups/run.sh
+++ b/block-fixups/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# Alert when there are fixup or squash commits
+#
+
+set -eo pipefail
+
+BRANCH_NAME="${GITHUB_REF##*/}"
+if [[ -z "$BRANCH_NAME" || -z "$DEFAULT_BRANCH" ]]; then
+  echo "BRANCH_NAME and DEFAULT_BRANCH must be set."
+  exit 1
+fi
+
+function merge_base() { git merge-base "origin/$DEFAULT_BRANCH" "origin/$BRANCH_NAME"; }
+
+function commit_list() { git log "$(merge_base)".."$BRANCH_NAME"; }
+
+FIXUPS=$(commit_list | grep -c "fixup\!\?" || true)
+SQUASHES=$(commit_list | grep -c "squash\!\?" || true)
+
+if [ "$FIXUPS" -gt "0" ] || [ "$SQUASHES" -gt "0" ]; then
+  echo "fixup! commits: ${FIXUPS}"
+  echo "squash! commits: ${SQUASHES}"
+  exit 1
+fi


### PR DESCRIPTION
## What is it?

Adds action which alerts you if any commit titles or messages on your PR contain the words `fixup!`/`fixup` or `squash!`/`squash`.

This has been requested as a feature so that people don't accidentally merge `fixup!` or `squash!` commits.

## How do I use it?

This action triggers on a branch push event. To include it you have to create a `.github/workflows/block_fixups.yml` file with the contents described in the README. 

NB: We've avoided hardcoding `master` anywhere, so the action is agnostic in regards to whether the default branch is `master` or `main`.

## Testing

PR using action: https://github.com/futurelearn/test-github-actions/pull/50
Success: https://github.com/futurelearn/test-github-actions/actions/runs/318703256
Failure: https://github.com/futurelearn/test-github-actions/runs/1283830188