### PR TITLE
Fix issue with notifications

### DIFF
--- a/notify/README.md
+++ b/notify/README.md
@@ -4,6 +4,11 @@ Sends a simple Slack notification for the results of a CI build.
 
 ## How to use
 
+### Inline
+
+If you use the action within a single job, it will automatically declare
+the status:
+
 ```
 name: CI
 on: push
@@ -19,4 +24,49 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK }}
           channel: #notifications
+```
+
+### Separate job
+
+If you use the action as a separate job in a more complex pipeline where
+you're using the `needs` conditional, you will need to explicitly declare
+the status:
+
+```
+name: CI
+on: push
+
+jobs:
+  tests:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      ...
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    ...
+
+  notify_success:
+    if: success()
+    needs: [ tests, lint ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: futurelearn/actions/notify@main
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK }}
+        status: success
+        channel: #notifications
+
+  notify_failure:
+    if: failure()
+    needs: [ tests, lint ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: futurelearn/actions/notify@main
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK }}
+        status: failure
+        channel: #notifications
 ```

--- a/notify/action.yml
+++ b/notify/action.yml
@@ -4,6 +4,8 @@ inputs:
   webhook:
     description: "Full URL of the Slack webhook"
     required: true
+  status:
+    description: "The optional status of the job, either \"success\", \"failure\" or \"cancelled\""
   channel:
     description: "The channel to post the notification to"
     required: true
@@ -16,6 +18,7 @@ runs:
       env:
         COMMIT_AUTHOR: ${{ github.event.pusher.name }}
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        DEFINED_JOB_STATUS: ${{ inputs.status }}
         JOB_STATUS: ${{ job.status }}
         SLACK_CHANNEL: ${{ inputs.channel }}
         SLACK_WEBHOOK: ${{ inputs.webhook }}

--- a/notify/notify.sh
+++ b/notify/notify.sh
@@ -6,6 +6,10 @@
 BRANCH_NAME=$(echo "$GITHUB_REF" |cut -d "/" -f3)
 COMMIT_MESSAGE=$(echo "$COMMIT_MESSAGE" | head -n1)
 
+if [[ -n $DEFINED_JOB_STATUS ]]; then
+  JOB_STATUS=$DEFINED_JOB_STATUS
+fi
+
 case $JOB_STATUS in
   success)
     STATUS=":tada: Succeeded"


### PR DESCRIPTION
With a more complicated pipeline, you cannot use `job.status` to get the status of the full workflow, because it only reports the single job you're running it on. If you use the `needs` conditional, then it's going to give you inaccurate results.

Instead, what we can do is explicitly declare a success on success, and a failure on failure.
